### PR TITLE
Remove obsolete and add new compute capabilities

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -16,17 +16,18 @@ TARGETS := gputools.so
 
 # Compute capabilities 1.0 and 1.3 are obsolete
 # Add compute capabilities 3.5, 3.7, 5.0, 5.2
+
 NVCC := $(CUDA_HOME)/bin/nvcc -gencode arch=compute_20,code=sm_20 -gencode arch=compute_30,code=sm_30 -gencode arch=compute_35,code=sm_35 -gencode arch=compute_37,code=sm_37 -gencode arch=compute_50,code=sm_50 -gencode arch=compute_52,code=sm_52 -gencode arch=compute_52,code=compute_52
 
 all: $(TARGETS)
 
 $(TARGETS): $(OBJS)
-        $(NVCC) -shared $(LD_PARAMS) $(LIBS) $(OBJS) -o $@
+	$(NVCC) -shared $(LD_PARAMS) $(LIBS) $(OBJS) -o $@
 
 $(OBJS): %.o: %.$(EXT)
-        $(NVCC) -c $(INCS) $(PARAMS) $^ -o $@
+	$(NVCC) -c $(INCS) $(PARAMS) $^ -o $@
 
 clean:
-        rm -rf *o
+	rm -rf *o
 
 .PHONY: all clean

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,10 +1,8 @@
 include config.mk
 
-EXT := cu 
+EXT := cu
 
 OBJS := rinterface.o mi.o sort.o granger.o qrdecomp.o correlation.o hcluster.o distance.o matmult.o lsfit.o kendall.o cuseful.o
-
-R_HOME := $(shell $R RHOME)
 
 #compiler/preprocessor options
 INCS := -I. -I"$(CUDA_INC)" -I"$(R_INC)"
@@ -12,21 +10,21 @@ PARAMS := $(DEVICEOPTS) -Xcompiler $(CPICFLAGS)
 
 #linker options
 LD_PARAMS := $(DEVICEOPTS) -Xlinker '$(RPATH) $(R_FRAMEWORK)'
-LIBS :=  -L"$(R_LIB)" -L"$(CUDA_LIB)" -lcublas $(shell R CMD config BLAS_LIBS)
+LIBS :=  -L"$(R_LIB)" -L"$(CUDA_LIB)" -lcublas $(shell $(R_HOME)/bin/R CMD config BLAS_LIBS)
 
 TARGETS := gputools.so
 
 NVCC := $(CUDA_HOME)/bin/nvcc -gencode arch=compute_13,code=sm_13 -gencode arch=compute_20,code=sm_20 -gencode arch=compute_30,code=sm_30
 
-all: $(TARGETS) 
+all: $(TARGETS)
 
 $(TARGETS): $(OBJS)
-	$(NVCC) -shared $(LD_PARAMS) $(LIBS) $(OBJS) -o $@
+        $(NVCC) -shared $(LD_PARAMS) $(LIBS) $(OBJS) -o $@
 
 $(OBJS): %.o: %.$(EXT)
-	$(NVCC) -c $(INCS) $(PARAMS) $^ -o $@
+        $(NVCC) -c $(INCS) $(PARAMS) $^ -o $@
 
 clean:
-	rm -rf *o
+        rm -rf *o
 
 .PHONY: all clean

--- a/src/Makefile
+++ b/src/Makefile
@@ -16,7 +16,7 @@ LIBS :=  -L"$(R_LIB)" -L"$(CUDA_LIB)" -lcublas $(shell R CMD config BLAS_LIBS)
 
 TARGETS := gputools.so
 
-NVCC := $(CUDA_HOME)/bin/nvcc -gencode arch=compute_10,code=sm_10 -gencode arch=compute_13,code=sm_13 -gencode arch=compute_20,code=sm_20 -gencode arch=compute_30,code=sm_30
+NVCC := $(CUDA_HOME)/bin/nvcc -gencode -gencode arch=compute_13,code=sm_13 -gencode arch=compute_20,code=sm_20 -gencode arch=compute_30,code=sm_30
 
 all: $(TARGETS) 
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -14,7 +14,9 @@ LIBS :=  -L"$(R_LIB)" -L"$(CUDA_LIB)" -lcublas $(shell $(R_HOME)/bin/R CMD confi
 
 TARGETS := gputools.so
 
-NVCC := $(CUDA_HOME)/bin/nvcc -gencode arch=compute_13,code=sm_13 -gencode arch=compute_20,code=sm_20 -gencode arch=compute_30,code=sm_30
+# Compute capabilities 1.0 and 1.3 are obsolete
+# Add compute capabilities 3.5, 3.7, 5.0, 5.2
+NVCC := $(CUDA_HOME)/bin/nvcc -gencode arch=compute_20,code=sm_20 -gencode arch=compute_30,code=sm_30 -gencode arch=compute_35,code=sm_35 -gencode arch=compute_37,code=sm_37 -gencode arch=compute_50,code=sm_50 -gencode arch=compute_52,code=sm_52 -gencode arch=compute_52,code=compute_52
 
 all: $(TARGETS)
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -4,7 +4,7 @@ EXT := cu
 
 OBJS := rinterface.o mi.o sort.o granger.o qrdecomp.o correlation.o hcluster.o distance.o matmult.o lsfit.o kendall.o cuseful.o
 
-R_HOME := $(shell R RHOME)
+R_HOME := $(shell $R RHOME)
 
 #compiler/preprocessor options
 INCS := -I. -I"$(CUDA_INC)" -I"$(R_INC)"

--- a/src/Makefile
+++ b/src/Makefile
@@ -16,7 +16,7 @@ LIBS :=  -L"$(R_LIB)" -L"$(CUDA_LIB)" -lcublas $(shell R CMD config BLAS_LIBS)
 
 TARGETS := gputools.so
 
-NVCC := $(CUDA_HOME)/bin/nvcc -gencode -gencode arch=compute_13,code=sm_13 -gencode arch=compute_20,code=sm_20 -gencode arch=compute_30,code=sm_30
+NVCC := $(CUDA_HOME)/bin/nvcc -gencode arch=compute_13,code=sm_13 -gencode arch=compute_20,code=sm_20 -gencode arch=compute_30,code=sm_30
 
 all: $(TARGETS) 
 

--- a/src/config.mk
+++ b/src/config.mk
@@ -1,4 +1,4 @@
- set R_HOME, R_INC, and R_LIB to the the R install dir,
+# set R_HOME, R_INC, and R_LIB to the the R install dir,
 # the R header dir, and the R shared library dir on your system
 
 # R_HOME will be set in the R installation environment

--- a/src/config.mk
+++ b/src/config.mk
@@ -1,10 +1,9 @@
-# set R_HOME, R_INC, and R_LIB to the the R install dir,
+ set R_HOME, R_INC, and R_LIB to the the R install dir,
 # the R header dir, and the R shared library dir on your system
-ifndef R
-	R := R
-endif
+
+# R_HOME will be set in the R installation environment
 ifndef R_HOME
-	R_HOME := $(shell $R RHOME)
+    $(error R_HOME is not defined)
 endif
 R_INC := $(R_HOME)/include
 R_LIB := $(R_HOME)/lib
@@ -34,8 +33,9 @@ ifeq ($(OS), Darwin)
         DEVICEOPTS := -m64
     endif
     CUDA_LIB := $(CUDA_HOME)/lib
-    R_FRAMEWORK := -F$(R_HOME)/.. -framework R
+    R_FRAMEWORK_PATH := $(shell echo $(R_HOME) | sed 's|R.framework/Resources||')
+    R_FRAMEWORK := -F$(R_FRAMEWORK_PATH) -framework R
     RPATH := -rpath $(CUDA_LIB)
 endif
 
-CPICFLAGS := $(shell $R CMD config CPICFLAGS)
+CPICFLAGS := $(shell $(R_HOME)/bin/R CMD config CPICFLAGS)

--- a/src/config.mk
+++ b/src/config.mk
@@ -38,4 +38,4 @@ ifeq ($(OS), Darwin)
     RPATH := -rpath $(CUDA_LIB)
 endif
 
-CPICFLAGS := $(shell R CMD config CPICFLAGS)
+CPICFLAGS := $(shell $R CMD config CPICFLAGS)

--- a/src/config.mk
+++ b/src/config.mk
@@ -1,6 +1,11 @@
 # set R_HOME, R_INC, and R_LIB to the the R install dir,
 # the R header dir, and the R shared library dir on your system
-R_HOME := $(shell R RHOME)
+ifndef R
+	R := R
+endif
+ifndef R_HOME
+	R_HOME := $(shell $R RHOME)
+endif
 R_INC := $(R_HOME)/include
 R_LIB := $(R_HOME)/lib
 


### PR DESCRIPTION
Compilation fails under CUDA 6.5 and 7.0 as compute capabilities 1.0 and 1.3 are now obsolete. Newer compute capabilities 3.5, 3.7, 5.0 and 5.2 should be supported.
